### PR TITLE
最近の投稿ページの作成

### DIFF
--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -23,7 +23,7 @@
 	GNU General Public License for more details.
 
 	More about this license: http://www.gnu.org/licenses/gpl.html
-	
+
 */
 
 if ( !defined('QA_VERSION') )
@@ -41,7 +41,8 @@ qa_register_plugin_phrases('qa-recent-events-widget-lang-*.php', 'qa_recent_even
 // setting
 qa_register_plugin_module('module', 'q2apro-recent-events-admin.php', 'q2apro_recent_events', 'q2apro Recent Event');
 
-
+// page
+qa_register_plugin_module('page', 'qa-recent-events-page.php', 'qa_recent_events_page', 'Recent Events Page');
 
 // custom function to get all events and new events
 function getAllForumEvents($queryRecentEvents, $eventsToShow, $region) {
@@ -52,18 +53,18 @@ function getAllForumEvents($queryRecentEvents, $eventsToShow, $region) {
 
 	while ( ($row = qa_db_read_one_assoc($queryRecentEvents,true)) !== null ) {
 		if(in_array($row['event'], $eventsToShow)) {
-		
+
 			// question title
 			$qTitle = '';
-			
+
 			// workaround: convert tab jumps to & to be able to use query function
 			$toURL = str_replace("\t","&",$row['params']);
 			// echo $toURL."<br />"; // we get e.g. parentid=4523&parent=array(65)&postid=4524&answer=array(40)
 			parse_str($toURL, $data);  // parse URL to associative array $data
 			// now we can access the following variables in array $data if they exist in toURL
-			
+
 			$linkToPost = "-";
-			
+
 			// find out type, if Q set link directly, if A or C do query to get correct link
 			$postid = (isset($data['postid'])) ? $data['postid'] : null;
 			if($postid !== null) {
@@ -110,10 +111,10 @@ function getAllForumEvents($queryRecentEvents, $eventsToShow, $region) {
 					$linkToPost = $activity_url;
 				}
 			}
-			
+
 			$username = (is_null($row['handle'])) ? qa_lang_html('qa_recent_events_widget_lang/anonymous') : htmlspecialchars($row['handle']);
 			$usernameLink = (is_null($row['handle'])) ? qa_lang_html('qa_recent_events_widget_lang/anonymous') : '<a target="_blank" class="qa-user-link" style="font-weight:normal;" href="'.qa_opt('site_url').'user/'.$row['handle'].'">'.htmlspecialchars($row['handle']).'</a>';
-			
+
 			// set event name and css class
 			$eventName = '';
 			$eventNameShort = '';
@@ -159,15 +160,15 @@ function getAllForumEvents($queryRecentEvents, $eventsToShow, $region) {
 				}
 				$evTime .= qa_lang_html('qa_recent_events_widget_lang/ago');
 			}
-			
+
 			// if question title is empty, question got possibly deleted, do not show frontend!
 			if($qTitle=='') {
 				continue;
 			}
-			
+
 			// widget output, e.g. <a href="#" title="Antwort von echteinfachtv">17:23h A: Terme lösen und auskl...</a>
 			$qTitleShort = mb_substr($qTitle,0,22,'utf-8'); // shorten question title to 22 chars
-			$qTitleShort2 = (strlen($qTitle)>80) ? htmlspecialchars(mb_substr($qTitle,0,80,'utf-8')) .'&hellip;' : htmlspecialchars($qTitle); // shorten question title			
+			$qTitleShort2 = (strlen($qTitle)>80) ? htmlspecialchars(mb_substr($qTitle,0,80,'utf-8')) .'&hellip;' : htmlspecialchars($qTitle); // shorten question title
 			if ($region=='side') {
 				$listAllEvents .= '<a class="tipsify" href="'.$linkToPost.'" title="'.$eventName.' '.qa_lang_html('qa_recent_events_widget_lang/new_by').' '.$username.': '.htmlspecialchars($qTitle).'">';
 				$listAllEvents .= $evTime.' '.$eventNameShort. qa_lang_html('qa_recent_events_widget_lang/new_by') . $username .':'  .htmlspecialchars($qTitleShort).'&hellip;</a>';
@@ -185,8 +186,8 @@ function getAllForumEvents($queryRecentEvents, $eventsToShow, $region) {
 
 	return $listAllEvents;
 } // end function getAllForumEvents()
-		
-		
+
+
 /*
 	Omit PHP closing tag to help avoid accidental output
 */

--- a/qa-recent-events-page.php
+++ b/qa-recent-events-page.php
@@ -1,85 +1,254 @@
 <?php
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+	header('Location: ../../');
+	exit;
+}
 
-	class qa_recent_events_page {
+require_once QA_INCLUDE_DIR.'qa-db-selects.php';
 
-		var $directory;
-		var $urltoroot;
+class qa_recent_events_page {
 
-
-		function load_module($directory, $urltoroot)
-		{
-			$this->directory=$directory;
-			$this->urltoroot=$urltoroot;
-		}
-
-
-		function suggest_requests() // for display in admin interface
-		{
-			return array(
-				array(
-					'title' => 'Recent Events',
-					'request' => 'recent-events-page',
-					'nav' => 'M', // 'M'=main, 'F'=footer, 'B'=before main, 'O'=opposite main, null=none
-				),
-			);
-		}
+	var $directory;
+	var $urltoroot;
 
 
-		function match_request($request)
-		{
-			if ($request=='recent-events-page')
-				return true;
-
-			return false;
-		}
-
-
-		function process_request($request)
-		{
-			$qa_content=qa_content_prepare();
-
-			$qa_content['title']=qa_lang_html('qa_recent_events_widget_lang/page_title');
-			$qa_content['custom']='Some <b>custom html</b>';
-
-			$qa_content['form']=array(
-				'tags' => 'method="post" action="'.qa_self_html().'"',
-
-				'style' => 'wide',
-
-				'ok' => qa_post_text('okthen') ? 'You clicked OK then!' : null,
-
-				'title' => 'Form title',
-
-				'fields' => array(
-					'request' => array(
-						'label' => 'The request',
-						'tags' => 'name="request"',
-						'value' => qa_html($request),
-						'error' => qa_html('Another error'),
-					),
-
-				),
-
-				'buttons' => array(
-					'ok' => array(
-						'tags' => 'name="okthen"',
-						'label' => 'OK then',
-						'value' => '1',
-					),
-				),
-
-				'hidden' => array(
-					'hiddenfield' => '1',
-				),
-			);
-
-			$qa_content['custom_2']='<p><br>More <i>custom html</i></p>';
-
-			return $qa_content;
-		}
-
+	function load_module($directory, $urltoroot)
+	{
+		$this->directory=$directory;
+		$this->urltoroot=$urltoroot;
 	}
 
+
+	function suggest_requests() // for display in admin interface
+	{
+		return array(
+			array(
+				'title' => 'Recent Events',
+				'request' => 'recent-events-page',
+				'nav' => 'M', // 'M'=main, 'F'=footer, 'B'=before main, 'O'=opposite main, null=none
+			),
+		);
+	}
+
+
+	function match_request($request)
+	{
+		if ($request=='recent-events-page')
+			return true;
+
+		return false;
+	}
+
+
+	function process_request($request)
+	{
+		// 各条件を設定
+		$per_page = 50;		// ページあたりの表示件数
+		$create_day = date("Y-m-d H:i:s", strtotime('-30 day'));	// 何日分か
+		$params = array('q_post', 'a_post', 'c_post', 'a_select', $create_day);	// 取得対象イベント
+
+		$start = qa_get_start();
+		$total = $this->events_total($params);
+		$qa_content=qa_content_prepare();
+
+		$qa_content['title'] = qa_lang_html('qa_recent_events_widget_lang/page_title');
+		$count = $per_page * ($start + 1);
+		if ($count <= $total) {
+			$count_str = $start + 1 . ' ～ ' . $count . '件 ( ' . $total . '件中 )';
+		} else {
+			$count_str = $start + 1 . ' ～ ' . $total . '件 ( ' . $total . '件中 )';
+		}
+		$qa_content['custom'] = '<div style="text-align:right;"><span style="color:gray">'.$count_str.'</span></div>';
+		$qa_content['custom'] .= $this->get_recent_events($start, $per_page, $params);
+
+		// $qa_content['custom_2']='<p><br>More <i>custom html</i></p>';
+		$qa_content['page_links']=qa_html_page_links(qa_request(), $start, $per_page, $total, qa_opt('pages_prev_next'));
+
+		$qa_content['custom_2'] = '<DIV style="clear:both;"></DIV>';
+		return $qa_content;
+	}
+
+	function get_recent_events($start = 0, $count = 50, $params)
+	{
+		array_push($params, $start);
+		array_push($params, $count);
+		$sql = "SELECT datetime,ipaddress,handle,event,params
+				 FROM `^eventlog`
+				 WHERE (`event` = $
+				 OR `event` = $
+				 OR `event` = $
+				 OR `event` = $)
+				 AND `datetime` >= $
+				 ORDER BY datetime DESC
+				 LIMIT #, #";
+
+		$queryRecentEvents = qa_db_query_sub(qa_db_apply_sub($sql, $params));
+		$eventsToShow = array_slice($params, 0, 4);
+		return $this->get_events_html($queryRecentEvents, $eventsToShow);
+	}
+
+	function get_events_html($queryRecentEvents, $eventsToShow)
+	{
+		$html = '';
+		$events = qa_db_read_all_assoc($queryRecentEvents);
+
+		if (count($events) <= 0) {
+			return $html;
+		}
+
+		$html = '<div class="recent-events-container">';
+		$html .= '<ul>';
+		foreach ($events as $row) {
+			if (!in_array($row['event'], $eventsToShow)) {
+				continue;
+			}
+
+			// question title
+			$qTitle = '';
+
+			// workaround: convert tab jumps to & to be able to use query function
+			$toURL = str_replace("\t","&",$row['params']);
+			// echo $toURL."<br />"; // we get e.g. parentid=4523&parent=array(65)&postid=4524&answer=array(40)
+			parse_str($toURL, $data);  // parse URL to associative array $data
+			// now we can access the following variables in array $data if they exist in toURL
+
+			$linkToPost = "-";
+
+			// find out type, if Q set link directly, if A or C do query to get correct link
+			$postid = (isset($data['postid'])) ? $data['postid'] : null;
+			if($postid !== null) {
+				$getPostType = qa_db_read_one_assoc( qa_db_query_sub("SELECT type,parentid FROM `^posts` WHERE `postid` = #", $postid) );
+				$postType = $getPostType['type']; // type, and $getPostType[1] is parentid
+				if($postType=="A") {
+					$getQtitle = qa_db_read_one_value( qa_db_query_sub("SELECT title FROM `^posts` WHERE `postid` = #", $getPostType['parentid']), true );
+					$qTitle = (isset($getQtitle)) ? $getQtitle : "";
+					// get correct public URL
+					$activity_url = qa_path_html(qa_q_request($getPostType['parentid'], $qTitle), null, qa_opt('site_url'), null, null);
+					$linkToPost = $activity_url."?show=".$postid."#a".$postid;
+				}
+				else if($postType=="C") {
+					// get question link from answer
+					$getQlink = qa_db_read_one_assoc( qa_db_query_sub("SELECT parentid,type FROM `^posts` WHERE `postid` = #", $getPostType['parentid']) );
+					$linkToQuestion = $getQlink['parentid'];
+					if($getQlink['type']=="A") {
+						$getQtitle = qa_db_read_one_value( qa_db_query_sub("SELECT title FROM `^posts` WHERE `postid` = #", $getQlink['parentid']), true );
+						$qTitle = (isset($getQtitle)) ? $getQtitle : "";
+						// get correct public URL
+						$activity_url = qa_path_html(qa_q_request($linkToQuestion, $qTitle), null, qa_opt('site_url'), null, null);
+						$linkToPost = $activity_url."?show=".$postid."#c".$postid;
+					}
+					else {
+						// default: comment on question
+						$getQtitle = qa_db_read_one_value( qa_db_query_sub("SELECT title FROM `^posts` WHERE `postid` = #", $getPostType['parentid']), true);
+						$qTitle = (isset($getQtitle)) ? $getQtitle : "";
+						// get correct public URL
+						$activity_url = qa_path_html(qa_q_request($getPostType['parentid'], $qTitle), null, qa_opt('site_url'), null, null);
+						$linkToPost = $activity_url."?show=".$postid."#c".$postid;
+					}
+				}
+				// if question is hidden, do not show frontend!
+				else if($postType=="Q_HIDDEN") {
+					$qTitle = '';
+				}
+				else {
+					// question has correct postid to link
+					// $questionTitle = (isset($data['title'])) ? $data['title'] : "";
+					$getQtitle = qa_db_read_one_value( qa_db_query_sub("SELECT title FROM `^posts` WHERE `postid` = #", $postid), true );
+					$qTitle = (isset($getQtitle)) ? $getQtitle : "";
+					// get correct public URL
+					$activity_url = qa_path_html(qa_q_request($postid, $qTitle), null, qa_opt('site_url'), null, null);
+					$linkToPost = $activity_url;
+				}
+			}
+
+			$username = (is_null($row['handle'])) ? qa_lang_html('qa_recent_events_widget_lang/anonymous') : htmlspecialchars($row['handle']);
+			$usernameLink = (is_null($row['handle'])) ? qa_lang_html('qa_recent_events_widget_lang/anonymous') : '<a target="_blank" class="qa-user-link" style="font-weight:normal;" href="'.qa_opt('site_url').'user/'.$row['handle'].'">'.htmlspecialchars($row['handle']).'</a>';
+
+			// set event name and css class
+			$eventName = '';
+			$eventNameShort = '';
+			if($row['event']=="q_post") {
+				$eventName = qa_lang_html('qa_recent_events_widget_lang/new_question');
+				$eventNameShort = qa_lang_html('qa_recent_events_widget_lang/new_question_abbr');
+			}
+			else if($row['event']=="a_post") {
+				$eventName = qa_lang_html('qa_recent_events_widget_lang/new_answer');
+				$eventNameShort = qa_lang_html('qa_recent_events_widget_lang/new_answer_abbr');
+			}
+			else if($row['event']=="c_post") {
+				$eventName = qa_lang_html('qa_recent_events_widget_lang/new_comment');
+				$eventNameShort = qa_lang_html('qa_recent_events_widget_lang/new_comment_abbr');
+			}
+			else if($row['event']=="a_select") {
+				$eventName = qa_lang_html('qa_recent_events_widget_lang/new_bestanswer');
+				$eventNameShort = qa_lang_html('qa_recent_events_widget_lang/new_bestanswer_abbr');
+			}
+			else if($row['event']=="u_register") {
+				$eventName = qa_lang_html('qa_recent_events_widget_lang/new_user');
+				$eventNameShort = qa_lang_html('qa_recent_events_widget_lang/new_user_abbr');
+				$linkToPost = $_SERVER['host']."index.php/user/$username";
+				$qTitle = $username." registered.";
+			}
+
+			$evTime = '';
+			// absolute time
+			if(qa_opt('q2apro_recent_events_time_format') === '0') {
+				$evTime = substr($row['datetime'],11,5) . qa_lang_html('qa_recent_events_widget_lang/hour_indic'); // 17:23h
+				// relative time
+			} else {
+				// display date as 'before x time'
+				$diff = time() - strtotime($row['datetime']);
+				if($diff<60){
+					$evTime = $diff . qa_lang_html('qa_recent_events_widget_lang/sec');
+				}else if($diff < 60*60){
+					$evTime = (int)($diff/60)  .  qa_lang_html('qa_recent_events_widget_lang/min');
+				}else if($diff < 60*60*24){
+					$evTime = (int)($diff/(60*60))  .  qa_lang_html('qa_recent_events_widget_lang/hour');
+				}else{
+					$evTime = (int)($diff/(60*60*24))  .  qa_lang_html('qa_recent_events_widget_lang/day');
+				}
+				$evTime .= qa_lang_html('qa_recent_events_widget_lang/ago');
+			}
+
+			// if question title is empty, question got possibly deleted, do not show frontend!
+			if($qTitle=='') {
+				continue;
+			}
+
+			// widget output, e.g. <a href="#" title="Antwort von echteinfachtv">17:23h A: Terme lösen und auskl...</a>
+			$qTitleShort = mb_substr($qTitle,0,22,'utf-8'); // shorten question title to 22 chars
+			$qTitleShort2 = (strlen($qTitle)>80) ? htmlspecialchars(mb_substr($qTitle,0,80,'utf-8')) .'&hellip;' : htmlspecialchars($qTitle); // shorten question title
+
+			$html .= '<li>';
+			$html .= '<div class="event-item-title">';
+			$html .= '<h3 style="margin: 10px 0 0 0;"><a href="'.$linkToPost.'">' . $qTitleShort2.'</a></h3>';
+			$html .= '</div>';
+			$html .= '<span class="event-item-meta">';
+			$html .= $evTime.' '.$eventName.' '.qa_lang_html('qa_recent_events_widget_lang/new_by').' '.$username;
+			$html .= '</span>';
+			$html .= '</li>';
+
+		}
+		$html .= '</ul>';
+		$html .= '</div>';
+		return $html;
+	}
+
+	function events_total($params)
+	{
+		// Get notifications total count for this user
+		$sql  = "SELECT count(*)
+				 FROM `^eventlog`
+				 WHERE (`event` = $
+				 OR `event` = $
+				 OR `event` = $
+				 OR `event` = $)
+				 AND `datetime` >= $";
+
+		return qa_db_read_one_value(qa_db_query_sub(qa_db_apply_sub($sql, $params)));
+	}
+
+}
 
 /*
 	Omit PHP closing tag to help avoid accidental output

--- a/qa-recent-events-page.php
+++ b/qa-recent-events-page.php
@@ -1,0 +1,87 @@
+<?php
+
+	class qa_recent_events_page {
+
+		var $directory;
+		var $urltoroot;
+
+
+		function load_module($directory, $urltoroot)
+		{
+			$this->directory=$directory;
+			$this->urltoroot=$urltoroot;
+		}
+
+
+		function suggest_requests() // for display in admin interface
+		{
+			return array(
+				array(
+					'title' => 'Recent Events',
+					'request' => 'recent-events-page',
+					'nav' => 'M', // 'M'=main, 'F'=footer, 'B'=before main, 'O'=opposite main, null=none
+				),
+			);
+		}
+
+
+		function match_request($request)
+		{
+			if ($request=='recent-events-page')
+				return true;
+
+			return false;
+		}
+
+
+		function process_request($request)
+		{
+			$qa_content=qa_content_prepare();
+
+			$qa_content['title']=qa_lang_html('example_page/page_title');
+			$qa_content['error']='An example error';
+			$qa_content['custom']='Some <b>custom html</b>';
+
+			$qa_content['form']=array(
+				'tags' => 'method="post" action="'.qa_self_html().'"',
+
+				'style' => 'wide',
+
+				'ok' => qa_post_text('okthen') ? 'You clicked OK then!' : null,
+
+				'title' => 'Form title',
+
+				'fields' => array(
+					'request' => array(
+						'label' => 'The request',
+						'tags' => 'name="request"',
+						'value' => qa_html($request),
+						'error' => qa_html('Another error'),
+					),
+
+				),
+
+				'buttons' => array(
+					'ok' => array(
+						'tags' => 'name="okthen"',
+						'label' => 'OK then',
+						'value' => '1',
+					),
+				),
+
+				'hidden' => array(
+					'hiddenfield' => '1',
+				),
+			);
+
+			$qa_content['custom_2']='<p><br>More <i>custom html</i></p>';
+
+			return $qa_content;
+		}
+
+	}
+
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-recent-events-page.php
+++ b/qa-recent-events-page.php
@@ -4,8 +4,6 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 	exit;
 }
 
-require_once QA_INCLUDE_DIR.'qa-db-selects.php';
-
 class qa_recent_events_page {
 
 	var $directory;
@@ -24,7 +22,7 @@ class qa_recent_events_page {
 		return array(
 			array(
 				'title' => 'Recent Events',
-				'request' => 'recent-events-page',
+				'request' => 'recent-events',
 				'nav' => 'M', // 'M'=main, 'F'=footer, 'B'=before main, 'O'=opposite main, null=none
 			),
 		);
@@ -33,7 +31,7 @@ class qa_recent_events_page {
 
 	function match_request($request)
 	{
-		if ($request=='recent-events-page')
+		if ($request=='recent-events')
 			return true;
 
 		return false;
@@ -45,7 +43,7 @@ class qa_recent_events_page {
 		// 各条件を設定
 		$per_page = 50;		// ページあたりの表示件数
 		$create_day = date("Y-m-d H:i:s", strtotime('-30 day'));	// 何日分か
-		$params = array('q_post', 'a_post', 'c_post', 'a_select', $create_day);	// 取得対象イベント
+		$params = array('q_post', 'a_post', 'c_post', 'a_select', $create_day);	// 対象イベント
 
 		$start = qa_get_start();
 		$total = $this->events_total($params);

--- a/qa-recent-events-page.php
+++ b/qa-recent-events-page.php
@@ -38,8 +38,7 @@
 		{
 			$qa_content=qa_content_prepare();
 
-			$qa_content['title']=qa_lang_html('example_page/page_title');
-			$qa_content['error']='An example error';
+			$qa_content['title']=qa_lang_html('qa_recent_events_widget_lang/page_title');
 			$qa_content['custom']='Some <b>custom html</b>';
 
 			$qa_content['form']=array(

--- a/qa-recent-events-widget-lang-default.php
+++ b/qa-recent-events-widget-lang-default.php
@@ -20,17 +20,20 @@
 		'hour_indic' => 'h', // will appear behind time, e.g. 06:45h
 		'new_user_abbr' => 'R',
 		'new_user' => 'New User',
-		'ago' => 'ago', 
-		'day' => 'day', 
-		'hour' => 'hour', 
-		'min' => 'min', 
-		'sec' => 'sec', 
+		'ago' => 'ago',
+		'day' => 'day',
+		'hour' => 'hour',
+		'min' => 'min',
+		'sec' => 'sec',
 
 		// for setting
-		'admin_count' => 'count', 
-		'admin_time_format' => 'time format', 
+		'admin_count' => 'count',
+		'admin_time_format' => 'time format',
+
+		// for page
+		'page_title' => 'Recent Events',
 	);
-	
+
 
 /*
 	Omit PHP closing tag to help avoid accidental output

--- a/qa-recent-events-widget-lang-ja.php
+++ b/qa-recent-events-widget-lang-ja.php
@@ -20,17 +20,20 @@
 		'hour_indic' => '', // will appear behind time, e.g. 06:45h
 		'new_user_abbr' => 'ユーザー登録',
 		'new_user' => '新しいユーザー',
-		'ago' => '前', 
-		'day' => '日', 
-		'hour' => '時', 
-		'min' => '分', 
-		'sec' => '病', 
+		'ago' => '前',
+		'day' => '日',
+		'hour' => '時',
+		'min' => '分',
+		'sec' => '病',
 
 		// for setting
-		'admin_count' => 'count', 
-		'admin_time_format' => 'time format', 
+		'admin_count' => 'count',
+		'admin_time_format' => 'time format',
+
+		// for page
+		'page_title' => '最近の投稿',
 	);
-	
+
 
 /*
 	Omit PHP closing tag to help avoid accidental output


### PR DESCRIPTION
- URLは /recent-events
- 取得条件などは以下のとおり 
  - １ページあたり５０件
  - 過去３０日分
  - 対象イベント
    - 'q_post' 質問の投稿
    - 'a_post' 回答の投稿
    - 'c_post' コメントの投稿
    - 'a_select' ベストアンサーの選択
